### PR TITLE
bird: add unreachable route parsing

### DIFF
--- a/bird/parser_test.go
+++ b/bird/parser_test.go
@@ -83,14 +83,14 @@ func TestParseProtocolShort(t *testing.T) {
 }
 
 func TestParseRoutesAllIpv4Bird1(t *testing.T) {
-	runTestForIpv4WithFile("routes_bird1_ipv4.sample", t)
+	runTestForIpv4WithFile("routes_bird1_ipv4.sample", 4, t)
 }
 
 func TestParseRoutesAllIpv4Bird2(t *testing.T) {
-	runTestForIpv4WithFile("routes_bird2_ipv4.sample", t)
+	runTestForIpv4WithFile("routes_bird2_ipv4.sample", 5, t)
 }
 
-func runTestForIpv4WithFile(file string, t *testing.T) {
+func runTestForIpv4WithFile(file string, numRoutes int, t *testing.T) {
 	f, err := openFile(file)
 	if err != nil {
 		t.Error(err)
@@ -103,8 +103,8 @@ func runTestForIpv4WithFile(file string, t *testing.T) {
 		t.Fatal("Error getting routes")
 	}
 
-	if len(routes) != 4 {
-		t.Fatal("Expected 4 routes but got ", len(routes))
+	if len(routes) != numRoutes {
+		t.Fatalf("Expected %v routes but got %v", numRoutes, len(routes))
 	}
 
 	assertRouteIsEqual(expectedRoute{
@@ -248,14 +248,14 @@ func runTestForIpv4WithFile(file string, t *testing.T) {
 }
 
 func TestParseRoutesAllIpv6Bird1(t *testing.T) {
-	runTestForIpv6WithFile("routes_bird1_ipv6.sample", t)
+	runTestForIpv6WithFile("routes_bird1_ipv6.sample", 3, t)
 }
 
 func TestParseRoutesAllIpv6Bird2(t *testing.T) {
-	runTestForIpv6WithFile("routes_bird2_ipv6.sample", t)
+	runTestForIpv6WithFile("routes_bird2_ipv6.sample", 4, t)
 }
 
-func runTestForIpv6WithFile(file string, t *testing.T) {
+func runTestForIpv6WithFile(file string, numRoutes int, t *testing.T) {
 	f, err := openFile(file)
 	if err != nil {
 		t.Error(err)
@@ -268,8 +268,8 @@ func runTestForIpv6WithFile(file string, t *testing.T) {
 		t.Fatal("Error getting routes")
 	}
 
-	if len(routes) != 3 {
-		t.Fatal("Expected 3 routes but got ", len(routes))
+	if len(routes) != numRoutes {
+		t.Fatalf("Expected %v routes but got %v", numRoutes, len(routes))
 	}
 
 	assertRouteIsEqual(expectedRoute{

--- a/test/routes_bird2_ipv4.sample
+++ b/test/routes_bird2_ipv4.sample
@@ -40,3 +40,4 @@ BIRD 1.6.3 ready.
 	BGP.community: (65011,3) (9033,3251)
 	BGP.large_community: (9033, 65666, 12) (9033, 65666, 9)
 	BGP.ext_community: (rt, 42, 1234) (generic, 0x43000000, 0x1) 
+10.39.144.8/32       unreachable [s2r7node16 2020-03-30 19:24:34 from 10.38.151.48] * (100/-) [AS4200980000?]

--- a/test/routes_bird2_ipv6.sample
+++ b/test/routes_bird2_ipv6.sample
@@ -32,3 +32,4 @@ BIRD 2.0.0 ready.
     BGP.community: (48821,2000) (48821,2100)
     BGP.large_community: (48821, 0, 2000) (48821, 0, 2100)
     BGP.ext_community: (unknown 0x4300, 0, 1)
+fd53:616d:6d60:7::1000/124 unreachable [s2r7node16 2020-03-30 19:24:34 from 10.38.151.48] * (100/-) [AS4200980000?]


### PR DESCRIPTION
parses routes with the following format:
BIRD v2.0.4 ready.
Table master4:
10.39.144.8/32       unreachable [s2r7node16 2020-03-30 19:24:34 from 10.38.151.48] * (100/-) [AS4200980000?]

Table master6:
fd53:616d:6d60:7::1000/124 unreachable [s2r7node16 2020-03-30 19:24:34 from 10.38.151.48] * (100/-) [AS4200980000?]